### PR TITLE
Add X latest-post support

### DIFF
--- a/XNitterManager.ts
+++ b/XNitterManager.ts
@@ -1,0 +1,203 @@
+interface XPost {
+    id: string;
+    link: string;
+}
+
+interface XProfile {
+    avatar: string | null;
+    bio: string | null;
+    displayName: string | null;
+    username: string | null;
+    location: string | null;
+    website: string | null;
+    followers: number | null;
+}
+const decodePbsImage = (src: string): string => {
+    if (src.startsWith("/pic/")) {
+        return (
+            "https://" +
+            decodeURIComponent(src.replace("/pic/", ""))
+        );
+    }
+    return src;
+};
+class XNitterManager {
+    private baseUrl = "https://nitter.net";
+
+    // ---------- POSTS ----------
+
+    private extractLatestPost(html: string): XPost | null {
+        const items =
+            html.match(
+                /<div class="timeline-item[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/gi
+            ) || [];
+
+        for (const itemHtml of items) {
+            // ❌ Skip pinned + retweets
+            if (
+                itemHtml.includes('<div class="pinned">') ||
+                itemHtml.includes('<div class="retweet-header">')
+            ) {
+                continue;
+            }
+
+            const linkMatch = itemHtml.match(
+                /<a class="tweet-link" href="([^"]+)"/
+            );
+
+            if (!linkMatch) continue;
+
+            const path = linkMatch[1];
+
+            // ✅ Must be a real post
+            if (!path.includes("/status/")) {
+                continue;
+            }
+
+            // ❌ Skip posts that promote broadcasts
+            if (
+                itemHtml.includes("/broadcasts/") ||
+                itemHtml.includes("/i/broadcasts/")
+            ) {
+                continue;
+            }
+
+            const cleanPath = path.replace(/#m$/, "");
+
+            return {
+                id: cleanPath.split("/").pop()!,
+                link: `https://fixupx.com${cleanPath}`,
+            };
+        }
+
+        return null;
+    }
+
+    // ---------- PROFILE ----------
+
+    private extractProfile(html: string): XProfile {
+        // Avatar
+        const avatarMatch = html.match(
+            /<a class="profile-card-avatar"[\s\S]*?<img[^>]*src="([^"]+)"/i
+        );
+
+        // Bio
+        const bioMatch = html.match(
+            /<div class="profile-bio">[\s\S]*?<p[^>]*>([\s\S]*?)<\/p>/i
+        );
+
+        // Display name
+        const nameMatch = html.match(
+            /<a class="profile-card-fullname"[^>]*>([\s\S]*?)<\/a>/i
+        );
+
+        // Username
+        const usernameMatch = html.match(
+            /<a class="profile-card-username"[^>]*>@([^<]+)<\/a>/i
+        );
+
+        // Location
+        const locationMatch = html.match(
+            /<div class="profile-location">[\s\S]*?<span>([^<]+)<\/span>/i
+        );
+
+        // Website
+        const websiteMatch = html.match(
+            /<div class="profile-website">[\s\S]*?<a[^>]*href="([^"]+)"/i
+        );
+
+        // Followers
+        const followersMatch = html.match(
+            /<li class="followers">[\s\S]*?<span class="profile-stat-num">([^<]+)<\/span>/i
+        );
+
+        const avatar = avatarMatch
+            ? decodePbsImage(avatarMatch[1])
+            : null;
+
+        const bio = bioMatch
+            ? bioMatch[1].replace(/<[^>]+>/g, "").trim()
+            : null;
+
+        const displayName = nameMatch
+            ? nameMatch[1].replace(/<[^>]+>/g, "").trim()
+            : null;
+
+        const username = usernameMatch
+            ? `@${usernameMatch[1]}`
+            : null;
+
+        const location = locationMatch
+            ? locationMatch[1].trim()
+            : null;
+
+        const website = websiteMatch
+            ? websiteMatch[1].trim()
+            : null;
+
+        const followers = followersMatch
+            ? Number(
+                followersMatch[1]
+                    .replace(/,/g, "")
+                    .trim()
+            )
+            : null;
+
+        return {
+            avatar,
+            bio,
+            displayName,
+            username,
+            location,
+            website,
+            followers,
+        };
+    }
+
+    // ---------- PUBLIC API ----------
+
+    async getLatestPost(username: string): Promise<XPost | null> {
+        const html = await this.fetchProfileHtml(username);
+        if (!html) return null;
+        return this.extractLatestPost(html);
+    }
+
+    async getProfile(username: string): Promise<XProfile | null> {
+        const html = await this.fetchProfileHtml(username);
+        if (!html) return null;
+        return this.extractProfile(html);
+    }
+
+    private async fetchProfileHtml(
+        username: string
+    ): Promise<string | null> {
+        try {
+            const res = await fetch(`${this.baseUrl}/${username}`, {
+                headers: {
+                    accept:
+                        "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                    "accept-language": "en-US,en;q=0.5",
+                    "cache-control": "no-cache",
+                    "user-agent":
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+                },
+            });
+
+            if (!res.ok) {
+                console.error(
+                    `Nitter fetch failed for ${username}:`,
+                    res.status
+                );
+                return null;
+            }
+
+            return await res.text();
+        } catch (err) {
+            console.error("XNitterManager fetch error:", err);
+            return null;
+        }
+    }
+}
+
+export { XNitterManager };
+export type { XPost, XProfile };

--- a/commands/add.ts
+++ b/commands/add.ts
@@ -15,9 +15,11 @@ import {
     AddButtonDataYoutubeLatest,
     AddButtonDataYoutubeLatestShort,
     AddButtonDataKick,
+    AddButtonDataXLatestPost,
 } from "..";
 import platforms from "../platforms";
 import { normalizeTwitchUsername } from "../utils/normalize";
+import { XNitterManager } from "../XNitterManager";
 export default {
     data: new SlashCommandBuilder()
         .setName("add")
@@ -76,8 +78,8 @@ export default {
                 if (platform === "twitch") {
                     const dataLiveReq = await fetch(
                         process.env.API_SERVER_LIVE +
-                            "/twitch/" +
-                            usernameNormalized,
+                        "/twitch/" +
+                        usernameNormalized,
                         {
                             method: "GET",
                             headers: {
@@ -192,8 +194,8 @@ export default {
                 if (platform === "youtube-live") {
                     const dataLiveReq = await fetch(
                         process.env.API_SERVER_LIVE +
-                            "/youtube/@" +
-                            usernameClean,
+                        "/youtube/@" +
+                        usernameClean,
                         {
                             method: "GET",
                             headers: {
@@ -253,8 +255,8 @@ export default {
                 if (platform === "youtube-latest") {
                     const dataLiveReq = await fetch(
                         process.env.API_SERVER_LIVE +
-                            "/youtube/@" +
-                            usernameClean,
+                        "/youtube/@" +
+                        usernameClean,
                         {
                             method: "GET",
                             headers: {
@@ -313,8 +315,8 @@ export default {
                 if (platform === "youtube-short-latest") {
                     const dataLiveReq = await fetch(
                         process.env.API_SERVER_LIVE +
-                            "/youtube/@" +
-                            usernameClean,
+                        "/youtube/@" +
+                        usernameClean,
                         {
                             method: "GET",
                             headers: {
@@ -367,6 +369,48 @@ export default {
                         account: inter.user.id,
                         message: message || null,
                         youtube_id: dataLive.channel?.id || "",
+                    });
+                    return;
+                }
+                if (platform === "x") {
+                    const xManager = new XNitterManager();
+                    const profile = await xManager.getProfile(usernameClean || "");
+                    const bioLine = profile?.bio ? `Bio: ${profile.bio}\n\n` : "";
+                    const description = `${bioLine}${usernameClean} added by ${inter.user.username}`;
+                    const embed = new EmbedBuilder();
+                    embed.setTitle(`${profile?.displayName || usernameClean}`);
+                    embed.setDescription(description);
+                    embed.setURL(`https://x.com/${usernameClean}`);
+                    embed.setAuthor({
+                        name: "Doras Bot",
+                        iconURL: discord.user?.avatarURL() || "",
+                    });
+                    embed.setColor(0x1da1f2);
+                    embed.setImage(profile?.avatar || "");
+                    embed.setTimestamp();
+                    let buttonAccept = new ButtonBuilder();
+                    buttonAccept.setCustomId("accept-x-latest");
+                    buttonAccept.setLabel("Accept");
+                    buttonAccept.setStyle(ButtonStyle.Success);
+                    let buttonReject = new ButtonBuilder();
+                    buttonReject.setCustomId("reject-x-latest");
+                    buttonReject.setLabel("Reject");
+                    buttonReject.setStyle(ButtonStyle.Danger);
+                    const row = new ActionRowBuilder().addComponents(
+                        buttonAccept,
+                        buttonReject
+                    );
+                    const data = await inter.editReply({
+                        embeds: [embed],
+                        //@ts-expect-error
+                        components: [row],
+                    });
+                    AddButtonDataXLatestPost.set(data.id, {
+                        username: usernameClean,
+                        channel: channel?.id || "",
+                        server: inter.guild?.id || "",
+                        account: inter.user.id,
+                        message: message || null,
                     });
                     return;
                 }

--- a/commands/list.ts
+++ b/commands/list.ts
@@ -258,6 +258,53 @@ export default {
                 });
                 return;
             }
+            if (platform === "x") {
+                const users = await db
+                    .select()
+                    .from(schema.discordBotXLatestPost)
+                    .where(
+                        eq(
+                            schema.discordBotXLatestPost.server_id,
+                            inter.guildId
+                        )
+                    );
+                if (users.length === 0) {
+                    await inter.editReply({
+                        content: "No users found",
+                    });
+                    return;
+                }
+                const embeds = [];
+                const chunkSize = 25;
+                for (let i = 0; i < users.length; i += chunkSize) {
+                    const chunk = users.slice(i, i + chunkSize);
+                    let embed: any = {
+                        color: parseInt("1DA1F2", 16),
+                        title: "List of X latest post users",
+                        fields: chunk.map((user) => ({
+                            name: `@${user.username} added by`,
+                            value: `<@${user.account_id}> used in <#${user.channel_id}>`,
+                        })),
+                        thumbnail: {
+                            url: "https://cdn-icons-png.flaticon.com/512/733/733579.png",
+                        },
+                    };
+                    i == 0
+                        ? (embed.description = `Total X accounts: ${users.length}`)
+                        : "",
+                        embeds.push(embed);
+                }
+                if (embeds.length === 0) {
+                    await inter.editReply({
+                        content: "No users found",
+                    });
+                    return;
+                }
+                await inter.editReply({
+                    embeds: embeds.slice(0, 10),
+                });
+                return;
+            }
         } catch (error) {
             console.error("Error executing list command: ", error);
             await inter.editReply({

--- a/commands/remove.ts
+++ b/commands/remove.ts
@@ -229,6 +229,36 @@ export default {
                         content: "User removed",
                     });
                 }
+                if (platform === "x") {
+                    const data = await db
+                        .delete(schema.discordBotXLatestPost)
+                        .where(
+                            and(
+                                eq(
+                                    schema.discordBotXLatestPost.server_id,
+                                    inter.guildId
+                                ),
+                                eq(
+                                    schema.discordBotXLatestPost.username,
+                                    username?.replace("@", "")
+                                ),
+                                eq(
+                                    schema.discordBotXLatestPost.channel_id,
+                                    channel.id
+                                )
+                            )
+                        )
+                        .returning();
+                    if (data.length === 0) {
+                        await inter.editReply({
+                            content: "User not found",
+                        });
+                        return;
+                    }
+                    await inter.editReply({
+                        content: "User removed"
+                    });
+                }
             } catch (error) {
                 console.error("Error executing remove command: ", error);
                 await inter.editReply({

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -90,6 +90,19 @@ export const discordBotYoutubeLatestShort = pgTable(
     }
 );
 
+export const discordBotXLatestPost = pgTable("discord_bot_x_latest", {
+    id: uuid("id").primaryKey().notNull(),
+    account_id: text("account_id").notNull(),
+    server_id: text("server_id").notNull(),
+    channel_id: text("channel_id").notNull(),
+    username: text("username").notNull(),
+    x_post_id: text("x_post_id").notNull(),
+    message_id: text("message_id"),
+    social_links: boolean("social_links").default(false).notNull(),
+    social_link_url: text("social_link_url"),
+    message: text("message"),
+});
+
 export const discordBotServer = pgTable("discord_bot_server", {
     id: uuid("id").primaryKey().notNull(),
     account_id: text("account_id").notNull(),

--- a/events/interactionCreate.ts
+++ b/events/interactionCreate.ts
@@ -2,6 +2,7 @@ import { ChatInputCommandInteraction, Events, Interaction } from "discord.js";
 import {
     AddButtonDataKick,
     AddButtonDataTwitch,
+    AddButtonDataXLatestPost,
     AddButtonDataYoutubeLatest,
     AddButtonDataYoutubeLatestShort,
     AddButtonDataYoutubeLive,
@@ -9,6 +10,7 @@ import {
     discord,
     kickLiveEmbeds,
     twitchLiveEmbeds,
+    xLatestPostEmbeds,
 } from "..";
 import { db } from "../db";
 import * as schema from "../db/schema";
@@ -323,6 +325,64 @@ discord.on(
                         break;
                     case "reject-youtube-latest":
                         AddButtonDataYoutubeLatestShort.delete(
+                            interaction.message.id
+                        );
+                        await interaction.reply({
+                            content: "User has rejected",
+                            ephemeral: true,
+                        });
+                        break;
+                    case "accept-x-latest":
+                        const dataXLatest = AddButtonDataXLatestPost.get(
+                            interaction.message.id
+                        );
+                        if (!dataXLatest) {
+                            await interaction.reply({
+                                content: "Button pressed but no data found.",
+                                ephemeral: true,
+                            });
+                            AddButtonDataXLatestPost.delete(
+                                interaction.message.id
+                            );
+                            return;
+                        }
+                        const dataDBXLatest = await db
+                            .insert(schema.discordBotXLatestPost)
+                            .values({
+                                id: randomUUID(),
+                                account_id: interaction.user.id,
+                                channel_id: dataXLatest?.channel || "",
+                                server_id: dataXLatest.server || "",
+                                username: dataXLatest.username || "",
+                                social_links: false,
+                                message: dataXLatest.message || null,
+                                x_post_id: "",
+                            })
+                            .returning();
+                        if (!dataDBXLatest) {
+                            await interaction.reply({
+                                content:
+                                    "There was an error executing the command.",
+                                ephemeral: true,
+                            });
+                            AddButtonDataXLatestPost.delete(
+                                interaction.message.id
+                            );
+                            return;
+                        } else {
+                            await interaction.reply({
+                                content: `${dataXLatest.username} has been added to the database.`,
+                                ephemeral: true,
+                            });
+                            await xLatestPostEmbeds(dataDBXLatest[0], -50);
+
+                            AddButtonDataXLatestPost.delete(
+                                interaction.message.id
+                            );
+                        }
+                        break;
+                    case "reject-x-latest":
+                        AddButtonDataXLatestPost.delete(
                             interaction.message.id
                         );
                         await interaction.reply({

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import * as schema from "./db/schema";
 import {
     IKick,
     ITwitch,
+    IXLatestPost,
     IYoutubeLatest,
     IYoutubeLatestShort,
     IYoutubeLive,
@@ -31,6 +32,7 @@ export const AddButtonDataKick = new Map();
 export const AddButtonDataYoutubeLive = new Map();
 export const AddButtonDataYoutubeLatest = new Map();
 export const AddButtonDataYoutubeLatestShort = new Map();
+export const AddButtonDataXLatestPost = new Map();
 export const discord = new Client({
     intents: [
         GatewayIntentBits.Guilds,
@@ -83,6 +85,7 @@ discord.on(Events.ClientReady, async () => {
         await youtubeLiveEmbedLoop();
         await youtubeLatestEmbedLoop();
         await youtubeLatestShortEmbedLoop();
+        await xPostLatestLoop();
     });
     // const task = null;
     if (task) {
@@ -183,6 +186,7 @@ import "./events/interactionCreate";
 import "./server";
 import { createEventSubSubscription } from "./twitch";
 import { createEventSubSubscriptionKick } from "./kick";
+import { XNitterManager } from "./XNitterManager";
 // run every 10 minutes
 const TwitchEmbedLoop = async () => {
     if (process.env.TWITCH_EVENTSUB == "true") {
@@ -270,6 +274,16 @@ const youtubeLatestShortEmbedLoop = async () => {
     }
     console_log.log(
         `Youtube Latest Short Embeds Finished Processing ${servers.length} Users`
+    );
+};
+const xPostLatestLoop = async () => {
+    const servers = await db.query.discordBotXLatestPost.findMany();
+    console_log.log(`X Latest Post Embeds Processing ${servers.length} Users`);
+    for (const [index, item] of servers.entries()) {
+        await xLatestPostEmbeds(item, index);
+    }
+    console_log.log(
+        `X Latest Post Embeds Finished Processing ${servers.length} Users`
     );
 };
 export const twitchLiveEmbeds = async (item: ITwitch, index: number) => {
@@ -1632,6 +1646,78 @@ const youtubeLatestShortEmbeds = async (
         logger.log("END request (error)");
     }
 };
+
+export const xLatestPostEmbeds = async (item: IXLatestPost, index: number) => {
+    const logger = console_log.createReqLogger("X-LATEST-POST", {
+        user: item.username,
+        guild: item.server_id,
+        channel: item.channel_id,
+        index,
+    });
+    logger.log("START request");
+
+    const xManager = new XNitterManager();
+    const post = await xManager.getLatestPost(item.username);
+    if (!post) {
+        logger.warn("No posts found for user");
+        logger.log("END request");
+        return;
+    }
+    if (post?.id === item.x_post_id) {
+        logger.log(
+            `Post already processed (post_id=${post.id})`
+        );
+        logger.log("END request");
+        return;
+    }
+    const discordServer = discord.guilds.cache.get(item.server_id);
+    if (!discordServer) {
+        logger.error("Guild not found, aborting");
+        logger.log("END request");
+        return;
+    }
+    const channel = discordServer.channels.cache.get(item.channel_id);
+    if (!channel) {
+        logger.error("Channel not found, aborting");
+        logger.log("END request");
+        return;
+    }
+    try {
+        if (!channel.isTextBased()) {
+            logger.warn("Channel not text-based, aborting");
+            logger.log("END request");
+            return;
+        }
+
+        const row: any = new ActionRowBuilder();
+
+        if (item.social_links && item.social_link_url) {
+            row.addComponents(
+                new ButtonBuilder()
+                    .setLabel("Social Links")
+                    .setStyle(ButtonStyle.Link)
+                    .setURL(`https://doras.to/${item.social_link_url}`)
+            );
+        }
+        const message = await channel.send({
+            content: `${item.message}\n\n${post.link}`,
+            components: row.components.length ? [row] : [],
+        });
+        await db.update(schema.discordBotXLatestPost).set({
+            x_post_id: post.id,
+            message: item.message,
+            message_id: message.id,
+        }).where(eq(schema.discordBotXLatestPost.id, item.id));
+        logger.log(
+            `Message sent successfully (message_id=${message.id})`
+        );
+        logger.log("END request");
+    } catch (error) {
+        logger.error(
+            `Unhandled exception → ${error instanceof Error ? error.message : error}`
+        );
+    }
+}
 export const commands = new Map();
 async function registerSlashCommands() {
     let slashCommands = [];

--- a/platforms.ts
+++ b/platforms.ts
@@ -4,5 +4,6 @@ const platforms = [
     { name: "YouTube Live", value: "youtube-live" },
     { name: "YouTube Latest", value: "youtube-latest" },
     { name: "Youtube Short", value: "youtube-short-latest" },
+    { name: "X (formerly Twitter) – New Post", value: "x" },
 ];
 export default platforms;

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,7 @@ import {
     discordBotTwitch,
     discordBotYoutubeLatest,
     discordBotYoutubeLive,
+    discordBotXLatestPost,
     userServerAccess,
 } from "./db/schema";
 
@@ -11,6 +12,7 @@ export type IKick = typeof discordBotKick.$inferInsert;
 export type IYoutubeLive = typeof discordBotYoutubeLive.$inferInsert;
 export type IYoutubeLatest = typeof discordBotYoutubeLatest.$inferInsert;
 export type IYoutubeLatestShort = typeof discordBotYoutubeLatest.$inferInsert;
+export type IXLatestPost = typeof discordBotXLatestPost.$inferInsert;
 export type IUserServerAccess = typeof userServerAccess.$inferInsert & {
     servers: {
         id: string;


### PR DESCRIPTION
Add support for monitoring X (formerly Twitter) latest posts


This PR introduces support for tracking and posting the latest updates from X (formerly Twitter) accounts into Discord channels.

🚀 Features

- XNitterManager
	- Scrapes nitter.net to fetch profile data and latest posts.


- Latest post tracking
	- New database table: discord_bot_x_latest

	- Stores the last processed post_id to avoid duplicate posts.


- Platform integration
	- Adds X as a supported platform.

	- Fully integrated into existing add, list, and remove commands.


- Button flow
	- Adds AddButtonDataXLatestPost for accept/reject confirmation handling.


- Automated posting
	- xPostLatestLoop periodically checks for new posts.

	- xLatestPostEmbeds formats and sends new post links to Discord channels.


🛠️ Additional Changes

- Updated shared types to support the new platform.

- Minor command fetch and integration adjustments to support X latest posts.